### PR TITLE
1.0.5 changed the depends_on for brewed and external install

### DIFF
--- a/k2cli.rb
+++ b/k2cli.rb
@@ -4,7 +4,7 @@ class K2cli < Formula
   url "https://github.com/samsung-cnct/k2cli/releases/download/1.0.5/k2cli_1.0.5_darwin_amd64.tar.gz"
   sha256 "7e5c0fcd1a696cdbdf0c9bab0035e1c6b336b3b8d81ad7d568fbe54743d67a55"
 
-  depends_on "docker" => :run
+  depends_on "docker"
 
   def install
     bin.install "k2cli"


### PR DESCRIPTION
seeing if this fixes what @davidewatson is seeing.